### PR TITLE
Simplify DB setup by moving the .env at the root of the repository

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_PASSWORD=hskjdasj
+DB_USERNAME=asdhkajsdh
+DB=dakhdjka
+DB_HOST=ec2-23-23-247-245.compute-1.amazonaws.com

--- a/2 - server-query/.env.example
+++ b/2 - server-query/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USERNAME=asdhkajsdh
-DB=dakhdjka

--- a/2 - server-query/index.js
+++ b/2 - server-query/index.js
@@ -1,11 +1,11 @@
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 const { ApolloServer, gql } = require("apollo-server");
 const Sequelize = require("sequelize");
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${process.env.PASSWORD}@YOUR-HOST:5432/${
-    process.env.DB
-  }`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {

--- a/2.1 - server-query-solution/.env.example
+++ b/2.1 - server-query-solution/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USER=asdhkajsdh
-DB=dakhdjka

--- a/2.1 - server-query-solution/index.js
+++ b/2.1 - server-query-solution/index.js
@@ -1,11 +1,11 @@
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 const { ApolloServer, gql } = require("apollo-server");
 const Sequelize = require("sequelize");
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${
-    process.env.PASSWORD
-  }@ec2-23-23-247-245.compute-1.amazonaws.com:5432/${process.env.DB}`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {

--- a/3 - server-mutation/.env.example
+++ b/3 - server-mutation/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USERNAME=asdhkajsdh
-DB=dakhdjka

--- a/3 - server-mutation/index.js
+++ b/3 - server-mutation/index.js
@@ -1,12 +1,12 @@
 const { ApolloServer, gql } = require("apollo-server");
 const Sequelize = require("sequelize");
 
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${process.env.PASSWORD}@eYOUR-HOST:5432/${
-    process.env.DB
-  }`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {

--- a/3.1 - server-mutation-solution/.env.example
+++ b/3.1 - server-mutation-solution/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USER=asdhkajsdh
-DB=dakhdjka

--- a/3.1 - server-mutation-solution/index.js
+++ b/3.1 - server-mutation-solution/index.js
@@ -1,12 +1,12 @@
 const { ApolloServer, gql } = require("apollo-server");
 const Sequelize = require("sequelize");
 
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${
-    process.env.PASSWORD
-  }@ec2-23-23-247-245.compute-1.amazonaws.com:5432/${process.env.DB}`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {

--- a/3.2 - server-mutation-exercise/.env.example
+++ b/3.2 - server-mutation-exercise/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USER=asdhkajsdh
-DB=dakhdjka

--- a/3.2 - server-mutation-exercise/index.js
+++ b/3.2 - server-mutation-exercise/index.js
@@ -1,12 +1,12 @@
 const { ApolloServer, gql } = require("apollo-server");
 const Sequelize = require("sequelize");
 
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${
-    process.env.PASSWORD
-  }@ec2-23-23-247-245.compute-1.amazonaws.com:5432/${process.env.DB}`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {

--- a/3.2.1 - server-mutation-solution/.env.example
+++ b/3.2.1 - server-mutation-solution/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USER=asdhkajsdh
-DB=dakhdjka

--- a/3.2.1 - server-mutation-solution/index.js
+++ b/3.2.1 - server-mutation-solution/index.js
@@ -1,12 +1,12 @@
 const { ApolloServer, gql } = require("apollo-server");
 const Sequelize = require("sequelize");
 
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${
-    process.env.PASSWORD
-  }@ec2-23-23-247-245.compute-1.amazonaws.com:5432/${process.env.DB}`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {

--- a/4 - server-context/.env.example
+++ b/4 - server-context/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USER=asdhkajsdh
-DB=dakhdjka

--- a/4 - server-context/index.js
+++ b/4 - server-context/index.js
@@ -1,12 +1,12 @@
 const { ApolloServer, gql } = require("apollo-server");
 const Sequelize = require("sequelize");
 
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${process.env.PASSWORD}@eYOUR-HOST:5432/${
-    process.env.DB
-  }`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {

--- a/4.1 - server-context-solution/.env.example
+++ b/4.1 - server-context-solution/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USER=asdhkajsdh
-DB=dakhdjka

--- a/4.1 - server-context-solution/index.js
+++ b/4.1 - server-context-solution/index.js
@@ -1,12 +1,12 @@
 const { ApolloServer, gql } = require("apollo-server");
 const Sequelize = require("sequelize");
 
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${
-    process.env.PASSWORD
-  }@ec2-23-23-247-245.compute-1.amazonaws.com:5432/${process.env.DB}`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {

--- a/5 - server-combine/.env.example
+++ b/5 - server-combine/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USER=asdhkajsdh
-DB=dakhdjka

--- a/5 - server-combine/index.js
+++ b/5 - server-combine/index.js
@@ -1,12 +1,12 @@
 const { ApolloServer, gql } = require("apollo-server");
 const Sequelize = require("sequelize");
 
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${process.env.PASSWORD}@eYOUR-HOST:5432/${
-    process.env.DB
-  }`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {

--- a/5.1 - server-combine-solution/.env.example
+++ b/5.1 - server-combine-solution/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USER=asdhkajsdh
-DB=dakhdjka

--- a/5.1 - server-combine-solution/resolvers.js
+++ b/5.1 - server-combine-solution/resolvers.js
@@ -1,11 +1,11 @@
 const axios = require("axios");
 const Sequelize = require("sequelize");
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${
-    process.env.PASSWORD
-  }@ec2-23-23-247-245.compute-1.amazonaws.com:5432/${process.env.DB}`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {

--- a/5.2 - server-combine-exercise/.env.example
+++ b/5.2 - server-combine-exercise/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USER=asdhkajsdh
-DB=dakhdjka

--- a/5.2 - server-combine-exercise/resolvers.js
+++ b/5.2 - server-combine-exercise/resolvers.js
@@ -1,11 +1,11 @@
 const axios = require("axios");
 const Sequelize = require("sequelize");
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${
-    process.env.PASSWORD
-  }@ec2-23-23-247-245.compute-1.amazonaws.com:5432/${process.env.DB}`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {

--- a/5.2.1 - server-combine-exercise-solution/.env.example
+++ b/5.2.1 - server-combine-exercise-solution/.env.example
@@ -1,3 +1,0 @@
-PASSWORD=hskjdasj
-USER=asdhkajsdh
-DB=dakhdjka

--- a/5.2.1 - server-combine-exercise-solution/resolvers.js
+++ b/5.2.1 - server-combine-exercise-solution/resolvers.js
@@ -1,11 +1,11 @@
 const axios = require("axios");
 const Sequelize = require("sequelize");
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 
 const sequelize = new Sequelize(
-  `postgres://${process.env.USERNAME}:${
-    process.env.PASSWORD
-  }@ec2-23-23-247-245.compute-1.amazonaws.com:5432/${process.env.DB}`,
+  `postgres://${process.env.DB_USERNAME}:${process.env.DB_PASSWORD}@${
+    process.env.DB_HOST
+  }:5432/${process.env.DB}`,
   {
     ssl: true,
     dialectOptions: {


### PR DESCRIPTION
So now all projects use the same DB config; no more copy & paste at the
beginning of each exercises.

Also rename `USERNAME` into `DB_USERNAME` because on Linux USERNAME is set
to the Unix username and dotenv don't override it, therefore creating hard
to debug issue.